### PR TITLE
require pycddlib<3.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
 keywords = ["linear programming", "solver", "numerical optimization"]
 
 [project.optional-dependencies]
-cdd = ["pycddlib >=2.1.7"]
+cdd = ["pycddlib >=2.1.7,<3.0.0"]
 cvxopt = ["cvxopt >=1.2.6"]
 cvxpy = ["cvxpy >=1.1.11"]
 pdlp = ["ortools >=9.8.3296"]


### PR DESCRIPTION
Pycddlib is getting a big revamp to properly support type hints, and as a result the API is going to change quite a bit. To prevent users installing your package to experience problems, I suggest explicitly specifying pycddlib<3.0.0 in dependencies now, prior to pycddlib getting its new release out of beta, until the project has migrated to the new pycddlib API.

More info here: https://pycddlib.readthedocs.io/en/latest/changes.html